### PR TITLE
Fix excessive regeneration of spelling dictionaries

### DIFF
--- a/autoload/wordy.vim
+++ b/autoload/wordy.vim
@@ -34,12 +34,17 @@ function! wordy#init(...) abort
     let l:src_path = l:data_dir . '/' . l:lang . '/' . l:dict . '.dic'
     if filereadable(l:src_path)
       if has('nvim')
-        " Dynamically convert SpellBad words into SpellRare words under NeoVim.
-        " See issue 15 for details: https://github.com/reedes/vim-wordy/pull/15
-        let l:rare_dic = map(readfile(l:src_path), "substitute(v:val, '!$', '?', '')")
-        let l:src_path = tempname()
-        call writefile(l:rare_dic, l:src_path)
+        let l:rare_path = l:src_path . '.rare'
+        if !filereadable(l:rare_path) ||
+          \ getftime(l:rare_path) < getftime(l:src_path)
+          " Dynamically convert SpellBad words into SpellRare words under NeoVim.
+          " See issue 15 for details: https://github.com/reedes/vim-wordy/pull/15
+          let l:rare_dic = map(readfile(l:src_path), "substitute(v:val, '!$', '?', '')")
+          call writefile(l:rare_dic, l:rare_path)
+        endif
+        let l:src_path = l:rare_path
       endif
+
       let l:spell_dir = g:wordy_dir . '/spell'
       if !isdirectory(l:spell_dir)
         call mkdir(expand(l:spell_dir), "p")


### PR DESCRIPTION
Due to the changes in #15 for neovim, a new dictionary for rare words is created each time `:WordyNext` or `:WordyPrev` is executed, even if the rare word dictionary is already up-to-date. This results in a lot of chatter and requires the user to press <kbd>Enter</kbd> to dismiss the messages. This change only creates a "rare words" dictionary when the original dictionary has changed.