### PR TITLE
Make cached spelling file directory configurable.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -283,6 +283,14 @@ instances of “’s”, such as “Joe’s not here.”
 And finally, `vague-time` finds where you are using vague descriptions of
 time where you could be more specific.
 
+## Configuration
+
+Change where `vim-wordy` stores cached spelling files using:
+
+```
+let g:wordy_spell_dir = '/home/my-user/wordy'
+```
+
 ## See also
 
 * [danielbmarques/vim-ditto][vd] - new plugin to highlight repeated words

--- a/autoload/wordy.vim
+++ b/autoload/wordy.vim
@@ -45,7 +45,7 @@ function! wordy#init(...) abort
         let l:src_path = l:rare_path
       endif
 
-      let l:spell_dir = g:wordy_dir . '/spell'
+      let l:spell_dir = g:wordy_spell_dir . '/spell'
       if !isdirectory(l:spell_dir)
         call mkdir(expand(l:spell_dir), "p")
       endif

--- a/plugin/wordy.vim
+++ b/plugin/wordy.vim
@@ -16,6 +16,10 @@ set cpo&vim
 " need directory to manage spell files
 let g:wordy_dir = fnamemodify(resolve(expand('<sfile>:p')), ':h:h')
 
+if !exists('g:wordy_spell_dir')
+  let g:wordy_spell_dir = g:wordy_dir
+endif
+
 command -nargs=0 NoWordy           call wordy#init({})
 
 command -nargs=0 NextWordy         call wordy#jump(1)


### PR DESCRIPTION
Introduces the `g:wordy_spell_dir` variable. This is useful with
`nixpkgs` or other distros where plugins are installed into unwritable
locations.